### PR TITLE
回答译者的问题

### DIFF
--- a/FunctionalProgrammingForTheRestOfUs.cn.md
+++ b/FunctionalProgrammingForTheRestOfUs.cn.md
@@ -285,7 +285,7 @@ unless(stock.isEuropean()) {
 }
 ```
 
-程序中只有在stock为European的时候才执行sendToSEC。如何实现例子中的unless？如果没有惰性求值就需要求助于某种形式的宏（译者：用if不行么？），不过在像Haskell这样的语言中就不需要那么麻烦了。直接实现一个unless函数就可以！
+程序中只有在stock为European的时候才执行sendToSEC。如何实现例子中的unless？如果没有惰性求值就需要求助于某种形式的宏，不过在像Haskell这样的语言中就不需要那么麻烦了。直接实现一个unless函数就可以！
 
 ```haskell
 void unless(boolean condition, List code) {


### PR DESCRIPTION
这里作者强调的是在Java中永远不能实现`unless`这样的控制结构或函数。
像下面用`if (!sth)`来替代`unless (sth)当然是可以的，

``` Java
if (!stock.isEuropean()) {
    sendToSEC(stock);
}
```

但还是没有实现`unless`。
